### PR TITLE
Set load balancer to be internal on private subnet

### DIFF
--- a/replay-handler-cloudformation.yaml
+++ b/replay-handler-cloudformation.yaml
@@ -229,6 +229,7 @@ Resources:
   NetworkLoadBalancer:
     Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
     Properties:
+      Scheme: internal
       Subnets: !Ref HandlerSubnetIds
       Type: network
       LoadBalancerAttributes:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Following the [tutorial](https://aws.amazon.com/blogs/networking-and-content-delivery/mirror-production-traffic-to-test-environment-with-vpc-traffic-mirroring/), one ends up with an internet-facing load balancer on a private subnet. This configuration seems incorrect so adding the configuration flag to create an internal LB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
