### PR TITLE
Keep Host header intact

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ var fwdPerc = flag.Float64("percentage", 100, "Must be between 0 and 100.")
 var fwdBy = flag.String("percentage-by", "", "Can be empty. Otherwise, valid values are: header, remoteaddr.")
 var fwdHeader = flag.String("percentage-by-header", "", "If percentage-by is header, then specify the header here.")
 var reqPort = flag.Int("filter-request-port", 80, "Must be between 0 and 65535.")
+var keepHostHeader = flag.Bool("keep-host-header", false, "Keep Host header from original request.")
 
 // Build a simple HTTP request parser using tcpassembly.StreamFactory and tcpassembly.Stream interfaces
 
@@ -154,7 +155,9 @@ func forwardRequest(req *http.Request, reqSourceIP string, reqDestionationPort s
 		forwardReq.Header.Set("X-Forwarded-Host", req.Host)
 	}
 	
-	forwardReq.Host = req.Host
+	if keepHostHeader {
+		forwardReq.Host = req.Host
+	}
 
 	// Execute the new HTTP request
 	httpClient := &http.Client{}

--- a/main.go
+++ b/main.go
@@ -154,7 +154,7 @@ func forwardRequest(req *http.Request, reqSourceIP string, reqDestionationPort s
 		forwardReq.Header.Set("X-Forwarded-Host", req.Host)
 	}
 	
-	forwardReq.Header.Set("Host", req.Host)
+	forwardReq.Host = req.Host
 
 	// Execute the new HTTP request
 	httpClient := &http.Client{}

--- a/main.go
+++ b/main.go
@@ -153,6 +153,8 @@ func forwardRequest(req *http.Request, reqSourceIP string, reqDestionationPort s
 	if forwardReq.Header.Get("X-Forwarded-Host") == "" {
 		forwardReq.Header.Set("X-Forwarded-Host", req.Host)
 	}
+	
+	forwardReq.Header.Set("Host", req.Host)
 
 	// Execute the new HTTP request
 	httpClient := &http.Client{}

--- a/replay-handler-cloudformation.yaml
+++ b/replay-handler-cloudformation.yaml
@@ -121,6 +121,12 @@ Parameters:
   PercentageByHeader:
     Description: If the parameter PercentageBy is set to 'header', then enter the name of the header. Otherwise, leave it empty.
     Type: String
+  KeepOriginalHostHeader:
+    Description: Copy the original Host header from the mirrored request. Keep empty to set the Host header to RequestsForwardDestination.
+    Type: String
+    AlloedValues:
+      - ''
+      - '-keep-host-header'
 
 Metadata: 
   AWS::CloudFormation::Interface: 
@@ -225,7 +231,7 @@ Resources:
             - 'Fn::Sub': |
                 sudo ip link add vxlan0 type vxlan id ${TrafficMirroringVNI} dev eth0 dstport 4789
                 sudo ip link set vxlan0 up
-                $GOPATH"/bin/vxlan-to-http-request" -destination "${RequestsForwardDestination}" -percentage "${ForwardPercentage}" -percentage-by "${PercentageBy}" -percentage-by-header "${PercentageByHeader}" -filter-request-port "${FilterByDestinationPort}"
+                $GOPATH"/bin/vxlan-to-http-request" -destination "${RequestsForwardDestination}" -percentage "${ForwardPercentage}" -percentage-by "${PercentageBy}" -percentage-by-header "${PercentageByHeader}" -filter-request-port "${FilterByDestinationPort}" ${KeepOriginalHostHeader}
   NetworkLoadBalancer:
     Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
     Properties:

--- a/replay-handler-cloudformation.yaml
+++ b/replay-handler-cloudformation.yaml
@@ -124,6 +124,7 @@ Parameters:
   KeepOriginalHostHeader:
     Description: Copy the original Host header from the mirrored request. Keep empty to set the Host header to RequestsForwardDestination.
     Type: String
+    Default: ''
     AlloedValues:
       - ''
       - '-keep-host-header'


### PR DESCRIPTION
Set the `Host` header to match that of the original request. This allows to more easily handle the mirrored traffic, especially if the source handles multiple virtual hosts.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
