### PR TITLE
Support latest go version by using go modules

### DIFF
--- a/replay-handler-cloudformation.yaml
+++ b/replay-handler-cloudformation.yaml
@@ -222,7 +222,7 @@ Resources:
             - 'Fn::Sub': |
                 sudo ip link add vxlan0 type vxlan id ${TrafficMirroringVNI} dev eth0 dstport 4789
                 sudo ip link set vxlan0 up
-                $GOPATH"/bin/vxlan-to-http-request" -destination "${RequestsForwardDestination}" -percentage "${ForwardPercentage}" -percentage-by "${PercentageBy}" -percentage-by-header "${PercentageByHeader}" -filter-request-port "${FilterByDestinationPort}"
+                $GOPATH"/bin/http-requests-mirroring" -destination "${RequestsForwardDestination}" -percentage "${ForwardPercentage}" -percentage-by "${PercentageBy}" -percentage-by-header "${PercentageByHeader}" -filter-request-port "${FilterByDestinationPort}"
   NetworkLoadBalancer:
     Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
     Properties:

--- a/replay-handler-cloudformation.yaml
+++ b/replay-handler-cloudformation.yaml
@@ -218,13 +218,7 @@ Resources:
               #
               ### create a virtual network interface that gets decapsulated VXLAN packets
               #### compile & run go script ###
-              mkdir -p $GOPATH"/src/vxlan-to-http-request"
-              wget https://github.com/aws-samples/http-requests-mirroring/raw/main/main.go -P $GOPATH"/src/vxlan-to-http-request"
-              pushd $GOPATH"/src/vxlan-to-http-request"
-              go mod init vxlan-to-http-request
-              go mod tidy
-              go install .
-              popd
+              go install github.com/aws-samples/http-requests-mirroring@latest
             - 'Fn::Sub': |
                 sudo ip link add vxlan0 type vxlan id ${TrafficMirroringVNI} dev eth0 dstport 4789
                 sudo ip link set vxlan0 up

--- a/replay-handler-cloudformation.yaml
+++ b/replay-handler-cloudformation.yaml
@@ -213,15 +213,18 @@ Resources:
               go env GOPATH
               echo 'export GOPATH=$HOME/go' >>~/.bash_profile
               source ~/.bash_profile
-              go get "github.com/google/gopacket"
               #
               #
               #
               ### create a virtual network interface that gets decapsulated VXLAN packets
               #### compile & run go script ###
-              mkdir $GOPATH"/src/vxlan-to-http-request"
+              mkdir -p $GOPATH"/src/vxlan-to-http-request"
               wget https://github.com/aws-samples/http-requests-mirroring/raw/main/main.go -P $GOPATH"/src/vxlan-to-http-request"
-              go install "vxlan-to-http-request"
+              pushd $GOPATH"/src/vxlan-to-http-request"
+              go mod init vxlan-to-http-request
+              go mod tidy
+              go install .
+              popd
             - 'Fn::Sub': |
                 sudo ip link add vxlan0 type vxlan id ${TrafficMirroringVNI} dev eth0 dstport 4789
                 sudo ip link set vxlan0 up


### PR DESCRIPTION
Fixes #6 

*Description of changes:*
Instead of relying on the old (deprecated) GOPATH installation of dependencies, use go modules.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
